### PR TITLE
fix typo in variable name

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
             --control-hover-text-color: #bbb;
 
             --note-bg-color: #fff;
-            --note-placeholer-color: #bbb;
+            --note-placeholder-color: #bbb;
             --note-link-color: #616161;
 
             --attribution-color: #bbb;

--- a/nash-ugly.html
+++ b/nash-ugly.html
@@ -18,7 +18,7 @@
       --control-hover-text-color: #bbb;
 
       --note-bg-color: #fff;
-      --note-placeholer-color: #bbb;
+      --note-placeholder-color: #bbb;
       --note-link-color: #616161;
 
       --attribution-color: #bbb;

--- a/nash.html
+++ b/nash.html
@@ -18,7 +18,7 @@
       --control-hover-text-color: #bbb;
 
       --note-bg-color: #fff;
-      --note-placeholer-color: #bbb;
+      --note-placeholder-color: #bbb;
       --note-link-color: #616161;
 
       --attribution-color: #bbb;


### PR DESCRIPTION
There is a typo in the variable name of placeholder color in light mode